### PR TITLE
[performerBodyCalculator] Fix HeightType.match_threshold

### DIFF
--- a/plugins/performerBodyCalculator/body_tags.py
+++ b/plugins/performerBodyCalculator/body_tags.py
@@ -170,7 +170,7 @@ F_HEIGHT_SD = 7.07
 class HeightType(StashTagEnumComparable):
     # threshold based off of performer.height_cm
     SHORT   = StashTagDC(threshold=(operator.le, F_HEIGHT_MEAN - F_HEIGHT_SD))
-    AVERAGE  = StashTagDC(threshold=(operator.le, F_HEIGHT_MEAN - F_HEIGHT_SD))
+    AVERAGE  = StashTagDC(threshold=(operator.lt, F_HEIGHT_MEAN + F_HEIGHT_SD))
     TALL    = StashTagDC(threshold=(operator.ge, F_HEIGHT_MEAN + F_HEIGHT_SD))
 
 class BreastSize(StashTagEnumComparable):

--- a/plugins/performerBodyCalculator/performer_calculator.py
+++ b/plugins/performerBodyCalculator/performer_calculator.py
@@ -178,10 +178,7 @@ class StashPerformer:
         # only tuned on female heights
         if not self.height_cm or self.gender != 'FEMALE':
             return
-        if self.height_cm > 160 and self.height_cm < 180:
-            height_type = HeightType.AVERAGE
-        else:
-            height_type = HeightType.match_threshold(self.height_cm)
+        height_type = HeightType.match_threshold(self.height_cm)
         if height_type:
             self.tags_list.append(height_type)
 


### PR DESCRIPTION
Hello!

Thank you for creating and publishing these plugins.

I was using the performer calculator plugin and noticed that it was tagging heights incorrectly. I took a look at the code and found a minus that should be a plus in the `HeightType.match_threshold` function. 

In the function `set_height_type` I removed the average height check because now that the `match_threshold` function works, it seems like this check is no longer necessary.