### PR TITLE
[performerBodyCalculator] More height tags

### DIFF
--- a/plugins/performerBodyCalculator/body_tags.py
+++ b/plugins/performerBodyCalculator/body_tags.py
@@ -170,9 +170,11 @@ F_HEIGHT_MEAN = 164.7
 F_HEIGHT_SD = 7.07
 class HeightType(StashTagEnumComparable):
     # threshold based off of performer.height_cm
-    SHORT   = StashTagDC(threshold=(operator.le, F_HEIGHT_MEAN - F_HEIGHT_SD))
+    TINY   = StashTagDC(threshold=(operator.le, F_HEIGHT_MEAN - F_HEIGHT_SD * 2))
+    SHORT   = StashTagDC(threshold=(operator.lt, F_HEIGHT_MEAN - F_HEIGHT_SD))
     AVERAGE  = StashTagDC(threshold=(operator.lt, F_HEIGHT_MEAN + F_HEIGHT_SD))
-    TALL    = StashTagDC(threshold=(operator.ge, F_HEIGHT_MEAN + F_HEIGHT_SD))
+    TALL    = StashTagDC(threshold=(operator.lt, F_HEIGHT_MEAN + F_HEIGHT_SD))
+    VERY_TALL    = StashTagDC(threshold=(operator.ge, F_HEIGHT_MEAN + F_HEIGHT_SD * 2))
 
 class BreastSize(StashTagEnumComparable):
     # threshold based off of performer.breast_volume

--- a/plugins/performerBodyCalculator/performer_calculator.py
+++ b/plugins/performerBodyCalculator/performer_calculator.py
@@ -74,7 +74,8 @@ class StashPerformer:
         self.measurements = self.measurements.replace(" ", "")
 
         if self.measurements == "":
-            raise DebugException(f"No measurements found for {str(self)}")
+           log.debug(f"No measurements found for {str(self)}")
+           return
 
         # Full Measurements | Band, Cup Size, Waist, Hips | Example: "32D-28-34"
         if band_cup_waist_hips := re.match(r'^(?P<band>\d+)(?P<cupsize>[a-zA-Z]+)\-(?P<waist>\d+)\-(?P<hips>\d+)$', self.measurements):


### PR DESCRIPTION
Most other metrics get tagged based on five or six tiers, but height only has 3. I've added  two new values (tiny and very tall), based on exceeding double standard deviation (which would be around 150 cm and 188 cm as the limits).

Another small change included here is not bailing out completely if the performer does not have measurements, height and weight alone still generate some tags.